### PR TITLE
Feat/deploy dx 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "blake3",
  "ciborium",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -304,9 +304,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake3"
@@ -577,6 +583,7 @@ dependencies = [
  "hex",
  "hkdf",
  "log",
+ "notify",
  "p256",
  "postcard",
  "quinn",
@@ -712,6 +719,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,11 +758,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -1129,6 +1145,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1177,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-core"
@@ -1587,6 +1622,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1738,26 @@ checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "elliptic-curve",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -2033,6 +2108,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -2064,6 +2151,25 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ntapi"
@@ -2124,7 +2230,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2742,7 +2848,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2785,7 +2891,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2961,7 +3067,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3042,7 +3148,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3209,7 +3315,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3359,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.1.1",
  "signal-hook",
 ]
 
@@ -3620,7 +3726,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3965,7 +4071,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -4181,6 +4287,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4228,6 +4343,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4280,6 +4410,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4298,6 +4434,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4313,6 +4455,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4346,6 +4494,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4361,6 +4515,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4382,6 +4542,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4397,6 +4563,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4483,7 +4655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.0",
  "indexmap 2.13.0",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +490,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +546,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1499,6 +1595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,7 +2079,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2057,6 +2159,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -2736,9 +2844,10 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "relay"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
+ "clap",
  "common",
  "crossterm",
  "ed25519-dalek",
@@ -2762,9 +2871,10 @@ dependencies = [
 
 [[package]]
 name = "resolver"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
+ "clap",
  "common",
  "ed25519-dalek",
  "governor",
@@ -3672,6 +3782,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["resolver", "relay", "common", "libcore", "jni_macro", "testnet"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/promtuz/promtuz"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.29"
 hex = "0.4.3"
 zeroize = "1.8"
 clap = { version = "4.5", features = ["derive"] }
+base64 = "0.22"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ toml = "0.9.8"
 log = "0.4.29"
 hex = "0.4.3"
 zeroize = "1.8"
+clap = { version = "4.5", features = ["derive"] }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ hex = "0.4.3"
 zeroize = "1.8"
 clap = { version = "4.5", features = ["derive"] }
 base64 = "0.22"
+notify = "6"
 
 [profile.release]
 opt-level = 3

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -21,6 +21,7 @@ quic = [
   "dep:quinn",
   "dep:blake3",
   "dep:data-encoding",
+  "dep:base64",
   "p256",
   "macros",
   "node",
@@ -68,6 +69,7 @@ sha2 = { version = "0.10.9", optional = true }
 zeroize = { workspace = true, optional = true }
 p256 = { version = "0.13.2", optional = true, features = ["pkcs8"] }
 rcgen = { version = "0.14.7", features = ["x509-parser"], optional = true }
+base64 = { workspace = true, optional = true }
 ciborium = "0.2.2"
 sysinfo = { version = "0.37.2", optional = true }
 serde_with = "3.16.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -34,7 +34,7 @@ certgen = ["quic", "crypto", "dep:rcgen"]
 node = []
 types = []
 # aka relay & resolver
-server = ["types", "dep:rand"]
+server = ["types", "dep:rand", "dep:notify"]
 # aka libcore
 client = ["types"]
 
@@ -55,7 +55,7 @@ quinn = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true, features = ["pkcs8", "pem", "zeroize"], optional = true }
 rustls-pemfile = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["io-util", "time", "net"], optional = true }
+tokio = { workspace = true, features = ["io-util", "time", "net", "sync", "macros", "rt"], optional = true }
 rand = { workspace = true, optional = true }
 
 blake3 = { version = "1.8.2", optional = true }
@@ -70,6 +70,7 @@ zeroize = { workspace = true, optional = true }
 p256 = { version = "0.13.2", optional = true, features = ["pkcs8"] }
 rcgen = { version = "0.14.7", features = ["x509-parser"], optional = true }
 base64 = { workspace = true, optional = true }
+notify = { workspace = true, optional = true }
 ciborium = "0.2.2"
 sysinfo = { version = "0.37.2", optional = true }
 serde_with = "3.16.1"

--- a/common/src/bin/certgen.rs
+++ b/common/src/bin/certgen.rs
@@ -8,7 +8,6 @@ use std::fs;
 use std::process::{
     self,
 };
-use base64::Engine as _;
 use common::quic::id::NodeId;
 use rcgen::{CertificateParams, SanType};
 use rcgen::DnType;
@@ -44,17 +43,24 @@ fn main() -> Result<(), Box<dyn Error>> {
         let csr_path = std::env::args().nth(2).ok_or("usage: certgen sign <csr-path>")?;
         let csr_pem = fs::read_to_string(&csr_path)?;
 
-        // rcgen verifies the PKCS#10 self-signature (proof of possession).
+        // rcgen parses the CSR and verifies its PKCS#10 self-signature (proof
+        // of possession) against the key it exposes as `public_key`.
+        use rcgen::PublicKeyData as _;
         let mut csr = rcgen::CertificateSigningRequestParams::from_pem(&csr_pem)?;
 
-        // Derive identity from the public key, never the CSR's claimed subject:
-        // a CA cert with an attacker-chosen CN would let one relay impersonate
-        // another on the client TLS path.
-        let der = base64::engine::general_purpose::STANDARD.decode(
-            csr_pem.lines().filter(|l| !l.starts_with("-----")).collect::<String>(),
-        )?;
-        let pubkey = common::node::enroll::spki_ed25519(&der)
-            .ok_or("CSR carries no Ed25519 public key")?;
+        // Derive identity ONLY from `public_key` — the exact key rcgen verified
+        // PoP against, and the one `signed_by` embeds as the cert SPKI. Never
+        // byte-scan the raw CSR: the attacker controls the subject/attribute
+        // bytes and could smuggle a second SPKI past a scan, yielding a cert
+        // whose real key is the attacker's but whose CN is a victim's NodeId.
+        if csr.public_key.algorithm() != &rcgen::PKCS_ED25519 {
+            return Err("CSR is not Ed25519".into());
+        }
+        let pubkey: [u8; 32] = csr
+            .public_key
+            .der_bytes()
+            .try_into()
+            .map_err(|_| "CSR public key is not a 32-byte Ed25519 key")?;
         let id = NodeId::new(&pubkey);
 
         csr.params.distinguished_name = rcgen::DistinguishedName::new();

--- a/common/src/bin/certgen.rs
+++ b/common/src/bin/certgen.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::process::{
     self,
 };
+use base64::Engine as _;
 use common::quic::id::NodeId;
 use rcgen::{CertificateParams, SanType};
 use rcgen::DnType;
@@ -37,6 +38,35 @@ fn main() -> Result<(), Box<dyn Error>> {
     let issuer = Issuer::from_ca_cert_pem(&root_ca_cert, &root_ca).inspect_err(|e| {
         dbg!(e);
     })?;
+
+    // `certgen sign <csr>`: issue a CA cert for an existing CSR's key.
+    if std::env::args().nth(1).as_deref() == Some("sign") {
+        let csr_path = std::env::args().nth(2).ok_or("usage: certgen sign <csr-path>")?;
+        let csr_pem = fs::read_to_string(&csr_path)?;
+
+        // rcgen verifies the PKCS#10 self-signature (proof of possession).
+        let mut csr = rcgen::CertificateSigningRequestParams::from_pem(&csr_pem)?;
+
+        // Derive identity from the public key, never the CSR's claimed subject:
+        // a CA cert with an attacker-chosen CN would let one relay impersonate
+        // another on the client TLS path.
+        let der = base64::engine::general_purpose::STANDARD.decode(
+            csr_pem.lines().filter(|l| !l.starts_with("-----")).collect::<String>(),
+        )?;
+        let pubkey = common::node::enroll::spki_ed25519(&der)
+            .ok_or("CSR carries no Ed25519 public key")?;
+        let id = NodeId::new(&pubkey);
+
+        csr.params.distinguished_name = rcgen::DistinguishedName::new();
+        csr.params.distinguished_name.push(DnType::CommonName, id.to_string());
+        csr.params.subject_alt_names = vec![SanType::DnsName(id.to_string().try_into()?)];
+
+        let cert = csr.signed_by(&issuer)?;
+        fs::create_dir_all(OUT_DIR)?;
+        fs::write(format!("{OUT_DIR}/{id}.crt"), cert.pem())?;
+        println!("signed {id}.crt");
+        return Ok(());
+    }
 
     let leaf_key = KeyPair::generate_for(&rcgen::PKCS_ED25519)?;
 

--- a/common/src/macros/mod.rs
+++ b/common/src/macros/mod.rs
@@ -6,7 +6,7 @@ macro_rules! graceful {
         match $expr {
             Ok(v) => v,
             Err(e) => {
-                $crate::error!("{} {}", $msg, e);
+                $crate::error!("{}: {}", $msg, e);
                 std::process::exit(1);
             },
         }

--- a/common/src/node/config.rs
+++ b/common/src/node/config.rs
@@ -18,6 +18,11 @@ pub struct NetworkConfig {
     pub key_path: PathBuf,
     /// root ca to verify outgoing/incoming quic connections
     pub root_ca_path: PathBuf,
+
+    /// Restart the daemon in place when this config file changes. Default off
+    /// — a bad edit otherwise risks an unwanted restart.
+    #[serde(default)]
+    pub watch_reload: bool,
 }
 
 /// Default QUIC ports, applied when a [`HostAddr`] in config omits one.

--- a/common/src/node/enroll.rs
+++ b/common/src/node/enroll.rs
@@ -165,4 +165,55 @@ mod tests {
             .expect("rcgen parses our hand-rolled CSR");
         let _ = std::fs::remove_file(&path);
     }
+
+    // Full loop: ephemeral CA → emit_csr → sign exactly as `certgen sign` →
+    // cert_is_valid must accept. Guards the keystone (a wrong reject = a node
+    // that waits for enrollment forever).
+    #[cfg(feature = "certgen")]
+    #[test]
+    fn accepts_our_ca_signed_cert() {
+        use rcgen::BasicConstraints;
+        use rcgen::CertificateParams;
+        use rcgen::DnType;
+        use rcgen::IsCa;
+        use rcgen::Issuer;
+        use rcgen::KeyPair;
+        use rcgen::SanType;
+
+        let _ = crate::quic::config::setup_crypto_provider();
+
+        // Ephemeral CA.
+        let ca_key = KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+        let ca_pem = ca_cert.pem();
+
+        // Node key + CSR.
+        let node = SigningKey::from_bytes(&[9u8; 32]);
+        let id = NodeId::new(&node.verifying_key().to_bytes());
+        let dir = std::env::temp_dir();
+        let csr_path = dir.join("pz_pos.csr");
+        emit_csr(&csr_path, &node, &id).unwrap();
+
+        // Sign exactly as `certgen sign` does (CN/SAN derived from the key).
+        let csr_pem = std::fs::read_to_string(&csr_path).unwrap();
+        let mut csr = rcgen::CertificateSigningRequestParams::from_pem(&csr_pem).unwrap();
+        csr.params.distinguished_name = rcgen::DistinguishedName::new();
+        csr.params.distinguished_name.push(DnType::CommonName, id.to_string());
+        csr.params.subject_alt_names = vec![SanType::DnsName(id.to_string().try_into().unwrap())];
+        let issuer = Issuer::from_ca_cert_pem(&ca_pem, &ca_key).unwrap();
+        let cert = csr.signed_by(&issuer).unwrap();
+
+        let cert_path = dir.join("pz_pos.crt");
+        let ca_path = dir.join("pz_pos_ca.pem");
+        std::fs::write(&cert_path, cert.pem()).unwrap();
+        std::fs::write(&ca_path, &ca_pem).unwrap();
+
+        assert!(cert_is_valid(&cert_path, &ca_path, &id, &node.verifying_key().to_bytes()));
+
+        for p in [csr_path, cert_path, ca_path] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
 }

--- a/common/src/node/enroll.rs
+++ b/common/src/node/enroll.rs
@@ -10,6 +10,10 @@ use rustls::pki_types::CertificateDer;
 use rustls::pki_types::ServerName;
 use rustls::pki_types::UnixTime;
 
+use base64::Engine as _;
+use ed25519_dalek::Signer;
+use ed25519_dalek::SigningKey;
+
 use crate::quic::config::load_root_ca;
 use crate::quic::id::NodeId;
 
@@ -60,6 +64,79 @@ pub fn cert_is_valid(
         .is_ok()
 }
 
+// ---------------------------------------------------------------------------
+// PKCS#10 CSR generation (hand-rolled Ed25519 DER; mirrors the self-signed
+// cert DER in `quic::config`). `certgen sign` re-derives CN/SAN from the
+// pubkey, so the request carries only version + subject(CN) + SPKI + empty
+// attributes, self-signed (proof of possession).
+// ---------------------------------------------------------------------------
+
+const ED25519_AID: &[u8] = &[0x06, 0x03, 0x2b, 0x65, 0x70];
+
+/// Minimal DER tag-length-value with short/long-form length.
+fn tlv(tag: u8, body: &[u8]) -> Vec<u8> {
+    let n = body.len();
+    if n < 128 {
+        [&[tag, n as u8][..], body].concat()
+    } else if n < 256 {
+        [&[tag, 0x81, n as u8][..], body].concat()
+    } else {
+        [&[tag, 0x82][..], &(n as u16).to_be_bytes(), body].concat()
+    }
+}
+
+fn spki_der(pubkey: &[u8; 32]) -> Vec<u8> {
+    [
+        &[0x30, 0x2a][..],
+        &[0x30, 0x05][..],
+        ED25519_AID,
+        &[0x03, 0x21, 0x00][..],
+        pubkey,
+    ]
+    .concat()
+}
+
+/// CertificationRequestInfo: version(0) + subject(CN) + SPKI + empty attrs.
+fn csr_info(pubkey: &[u8; 32], cn: &str) -> Vec<u8> {
+    let version: &[u8] = &[0x02, 0x01, 0x00];
+    let cn_oid: &[u8] = &[0x06, 0x03, 0x55, 0x04, 0x03]; // id-at-commonName
+    let cn_utf8 = [&[0x0c, cn.len() as u8][..], cn.as_bytes()].concat();
+    // Name ::= SEQUENCE OF RDN; RDN ::= SET OF AttributeTypeAndValue
+    let subject = tlv(0x30, &tlv(0x31, &tlv(0x30, &[cn_oid, &cn_utf8].concat())));
+    let attributes: &[u8] = &[0xa0, 0x00]; // [0] IMPLICIT SET OF, empty
+    tlv(0x30, &[version, &subject, &spki_der(pubkey), attributes].concat())
+}
+
+fn csr_der(info: &[u8], sig: &[u8; 64]) -> Vec<u8> {
+    let sig_alg = tlv(0x30, ED25519_AID);
+    let sig_bits = [&[0x03, 0x41, 0x00][..], sig].concat();
+    tlv(0x30, &[info, &sig_alg, &sig_bits].concat())
+}
+
+fn pem_wrap(label: &str, der: &[u8]) -> String {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(der);
+    let mut out = format!("-----BEGIN {label}-----\n");
+    for chunk in b64.as_bytes().chunks(64) {
+        out.push_str(std::str::from_utf8(chunk).unwrap_or_default());
+        out.push('\n');
+    }
+    out.push_str("-----END ");
+    out.push_str(label);
+    out.push_str("-----\n");
+    out
+}
+
+/// Write a PKCS#10 CSR (PEM) for `signing`'s key, `CN = base32(node_id)`.
+pub fn emit_csr(
+    csr_path: &Path, signing: &SigningKey, node_id: &NodeId,
+) -> std::io::Result<()> {
+    let pubkey = signing.verifying_key().to_bytes();
+    let info = csr_info(&pubkey, &node_id.to_string());
+    let sig = signing.sign(&info).to_bytes();
+    let der = csr_der(&info, &sig);
+    std::fs::write(csr_path, pem_wrap("CERTIFICATE REQUEST", &der))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,5 +150,19 @@ mod tests {
             &id,
             &[7u8; 32],
         ));
+    }
+
+    #[cfg(feature = "certgen")]
+    #[test]
+    fn csr_parses_with_rcgen() {
+        let key = SigningKey::from_bytes(&[3u8; 32]);
+        let id = NodeId::new(&key.verifying_key().to_bytes());
+        let path = std::env::temp_dir().join("pz_csr_roundtrip.csr");
+        emit_csr(&path, &key, &id).unwrap();
+        let pem = std::fs::read_to_string(&path).unwrap();
+        // from_pem validates the PKCS#10 structure AND the self-signature.
+        rcgen::CertificateSigningRequestParams::from_pem(&pem)
+            .expect("rcgen parses our hand-rolled CSR");
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/common/src/node/enroll.rs
+++ b/common/src/node/enroll.rs
@@ -226,10 +226,13 @@ mod tests {
 
 #[cfg(all(feature = "server", feature = "tokio"))]
 pub use orchestrate::ensure_enrolled;
+#[cfg(all(feature = "server", feature = "tokio"))]
+pub use orchestrate::spawn_config_reload;
 
 #[cfg(all(feature = "server", feature = "tokio"))]
 mod orchestrate {
     use std::path::Path;
+    use std::path::PathBuf;
     use std::time::Duration;
 
     use notify::RecursiveMode;
@@ -292,5 +295,53 @@ mod orchestrate {
                 return Ok(());
             }
         }
+    }
+
+    /// Watch the config file; on a change that still parses, re-exec the
+    /// process in place (PID-stable, independent of the systemd `Restart=`
+    /// policy). A parse failure logs and keeps running on the current config,
+    /// so a bad edit never crash-loops the node. Opt-in via `watch_reload`.
+    pub fn spawn_config_reload(config_path: PathBuf) {
+        tokio::spawn(async move {
+            let dir = config_path
+                .parent()
+                .unwrap_or_else(|| Path::new("/etc/promtuz"))
+                .to_path_buf();
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(8);
+            let Ok(mut watcher) = notify::recommended_watcher(move |_e| {
+                let _ = tx.blocking_send(());
+            }) else {
+                return;
+            };
+            if watcher.watch(&dir, RecursiveMode::NonRecursive).is_err() {
+                return;
+            }
+            let _keep = watcher;
+
+            while rx.recv().await.is_some() {
+                // Debounce: editors emit several events per save.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                while rx.try_recv().is_ok() {}
+
+                match std::fs::read_to_string(&config_path)
+                    .ok()
+                    .and_then(|s| toml::from_str::<toml::Value>(&s).ok())
+                {
+                    Some(_) => {
+                        crate::info!("config changed and parses; restarting in place");
+                        use std::os::unix::process::CommandExt as _;
+                        let err = std::process::Command::new(
+                            std::env::current_exe().unwrap_or_default(),
+                        )
+                        .args(std::env::args_os().skip(1))
+                        .exec();
+                        crate::warn!("re-exec failed: {err}; staying on the old config");
+                    },
+                    None => crate::warn!(
+                        "config changed but failed to parse; keeping current config"
+                    ),
+                }
+            }
+        });
     }
 }

--- a/common/src/node/enroll.rs
+++ b/common/src/node/enroll.rs
@@ -217,3 +217,80 @@ mod tests {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Async enrollment orchestration (daemon-side: needs tokio + notify).
+// Kept in a gated submodule so `certgen` (quic+crypto, no tokio) can still
+// use the sync helpers above.
+// ---------------------------------------------------------------------------
+
+#[cfg(all(feature = "server", feature = "tokio"))]
+pub use orchestrate::ensure_enrolled;
+
+#[cfg(all(feature = "server", feature = "tokio"))]
+mod orchestrate {
+    use std::path::Path;
+    use std::time::Duration;
+
+    use notify::RecursiveMode;
+    use notify::Watcher as _;
+
+    use super::cert_is_valid;
+    use super::emit_csr;
+    use crate::node::config::NetworkConfig;
+    use crate::quic::config::setup_crypto_provider;
+    use crate::quic::id::NodeId;
+    use crate::quic::p256::secret_from_key_or_create;
+
+    /// Ensure the node holds a valid cert for its key, or write a CSR and wait.
+    /// Returns once `cert_path` validates; otherwise blocks (never crash-loops).
+    pub async fn ensure_enrolled(
+        net: &NetworkConfig, csr_path: &Path, role: &str,
+    ) -> anyhow::Result<()> {
+        setup_crypto_provider()?;
+
+        let signing = secret_from_key_or_create(&net.key_path).map_err(|_| {
+            anyhow::anyhow!("loading/creating the node key at {}", net.key_path.display())
+        })?;
+        let key_pub = signing.verifying_key().to_bytes();
+        let node_id = NodeId::new(&key_pub);
+
+        if cert_is_valid(&net.cert_path, &net.root_ca_path, &node_id, &key_pub) {
+            let _ = std::fs::remove_file(csr_path);
+            return Ok(());
+        }
+
+        emit_csr(csr_path, &signing, &node_id)?;
+        crate::warn!(
+            "{role} not enrolled. Wrote CSR to {}. Sign it on the CA box \
+             (`certgen sign {}`), drop the signed cert at {}, and I start automatically.",
+            csr_path.display(),
+            csr_path.display(),
+            net.cert_path.display(),
+        );
+
+        // Watch the cert dir; a 5s poll backstops any missed inotify event.
+        let watch_dir = net
+            .cert_path
+            .parent()
+            .unwrap_or_else(|| Path::new("/etc/promtuz"))
+            .to_path_buf();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(8);
+        let mut watcher = notify::recommended_watcher(move |_evt| {
+            let _ = tx.blocking_send(());
+        })?;
+        watcher.watch(&watch_dir, RecursiveMode::NonRecursive)?;
+
+        loop {
+            tokio::select! {
+                _ = rx.recv() => {}
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+            }
+            if cert_is_valid(&net.cert_path, &net.root_ca_path, &node_id, &key_pub) {
+                let _ = std::fs::remove_file(csr_path);
+                crate::info!("{role} enrolled; cert accepted at {}", net.cert_path.display());
+                return Ok(());
+            }
+        }
+    }
+}

--- a/common/src/node/enroll.rs
+++ b/common/src/node/enroll.rs
@@ -1,0 +1,77 @@
+//! Node enrollment: load-or-create the single Ed25519 key, validate the
+//! CA-issued cert, or emit a CSR and wait. Shared by relay and resolver.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::client::WebPkiServerVerifier;
+use rustls::client::danger::ServerCertVerifier;
+use rustls::pki_types::CertificateDer;
+use rustls::pki_types::ServerName;
+use rustls::pki_types::UnixTime;
+
+use crate::quic::config::load_root_ca;
+use crate::quic::id::NodeId;
+
+/// Pull the 32-byte Ed25519 SPKI out of a DER cert. Ed25519 leaf certs carry
+/// exactly one `03 21 00` (33-byte) BIT STRING — the pubkey (the signature is
+/// `03 41 00`). Mirrors the hand-rolled DER in [`crate::quic::config`].
+pub fn spki_ed25519(cert_der: &[u8]) -> Option<[u8; 32]> {
+    let needle = [0x03, 0x21, 0x00];
+    let pos = cert_der.windows(3).position(|w| w == needle)? + 3;
+    cert_der.get(pos..pos + 32)?.try_into().ok()
+}
+
+fn first_cert_der(cert_path: &Path) -> Option<CertificateDer<'static>> {
+    let pem = std::fs::read(cert_path).ok()?;
+    let mut rd = std::io::BufReader::new(&pem[..]);
+    rustls_pemfile::certs(&mut rd).flatten().next()
+}
+
+/// True iff `cert_path` exists, chains to `ca_path`, is unexpired, names
+/// `node_id`, and its SPKI is our `key_pub` (i.e. it is *our* cert).
+///
+/// Requires the process crypto provider to be installed; the caller
+/// ([`ensure_enrolled`]) does this via `setup_crypto_provider`.
+pub fn cert_is_valid(
+    cert_path: &Path, ca_path: &Path, node_id: &NodeId, key_pub: &[u8; 32],
+) -> bool {
+    let Some(leaf) = first_cert_der(cert_path) else {
+        return false;
+    };
+
+    // It must certify *our* key, not just any CA-signed key.
+    if spki_ed25519(leaf.as_ref()).as_ref() != Some(key_pub) {
+        return false;
+    }
+
+    let Ok(roots) = load_root_ca(&ca_path.to_path_buf()) else {
+        return false;
+    };
+    let Ok(verifier) = WebPkiServerVerifier::builder(Arc::new(roots)).build() else {
+        return false;
+    };
+    let Ok(server_name) = ServerName::try_from(node_id.to_string()) else {
+        return false;
+    };
+
+    verifier
+        .verify_server_cert(&leaf, &[], &server_name, &[], UnixTime::now())
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_missing_cert() {
+        let id = NodeId::new(&[7u8; 32]);
+        assert!(!cert_is_valid(
+            Path::new("/nonexistent.crt"),
+            Path::new("/nonexistent_ca.pem"),
+            &id,
+            &[7u8; 32],
+        ));
+    }
+}

--- a/common/src/node/mod.rs
+++ b/common/src/node/mod.rs
@@ -1,4 +1,4 @@
 pub mod config;
 
-#[cfg(feature = "quic")]
+#[cfg(all(feature = "quic", feature = "crypto"))]
 pub mod enroll;

--- a/common/src/node/mod.rs
+++ b/common/src/node/mod.rs
@@ -1,1 +1,4 @@
 pub mod config;
+
+#[cfg(feature = "quic")]
+pub mod enroll;

--- a/common/src/proto/relay_res.rs
+++ b/common/src/proto/relay_res.rs
@@ -8,6 +8,7 @@ use tokio::io::AsyncWriteExt;
 
 use crate::proto::RelayId;
 use crate::proto::pack::Packer;
+use crate::debug;
 use crate::sysutils::SystemLoad;
 use crate::trace;
 use crate::types::bytes::Bytes;
@@ -140,6 +141,7 @@ impl ResolverPacket {
     pub async fn send(self, tx: &mut (impl AsyncWriteExt + Unpin)) -> anyhow::Result<()> {
         let packet = self.pack()?;
 
+        debug!("sent packet ({}B)", packet.len());
         trace!("sent packet {}", hex::encode(&packet));
 
         tx.write_all(&packet).await?;

--- a/common/src/quic/config.rs
+++ b/common/src/quic/config.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::quic::protorole::ProtoRole;
+use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::anyhow;
 use quinn::IdleTimeout;
@@ -58,8 +59,10 @@ fn default_client_transport() -> TransportConfig {
 }
 
 pub fn setup_crypto_provider() -> Result<()> {
-    CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider())
-        .map_err(|_| anyhow!("ERROR: failed to install default crypto provider"))?;
+    if CryptoProvider::get_default().is_none() {
+        CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider())
+            .map_err(|_| anyhow!("installing the default crypto provider"))?;
+    }
     Ok(())
 }
 
@@ -141,10 +144,14 @@ pub fn build_server_cfg(
     key_path: &Path,
     alpn_protocols: &'static [ProtoRole],
 ) -> Result<QuinnServerConfig> {
-    let mut cert_reader: BufReader<File> = BufReader::new(File::open(cert_path)?);
+    let mut cert_reader: BufReader<File> = BufReader::new(
+        File::open(cert_path).with_context(|| format!("reading TLS cert at {}", cert_path.display()))?,
+    );
     let certs = rustls_pemfile::certs(&mut cert_reader).flatten().collect();
 
-    let mut key_reader = BufReader::new(File::open(key_path)?);
+    let mut key_reader = BufReader::new(
+        File::open(key_path).with_context(|| format!("reading TLS key at {}", key_path.display()))?,
+    );
 
     let key = rustls_pemfile::private_key(&mut key_reader)?.ok_or(anyhow!("No Private Key"))?;
 
@@ -442,11 +449,15 @@ pub fn build_server_cfg_with_alpn_split(
     node_signing: ed25519_dalek::SigningKey,
     alpn_protocols: &'static [ProtoRole],
 ) -> Result<QuinnServerConfig> {
-    let mut cert_reader = BufReader::new(File::open(cert_path)?);
+    let mut cert_reader = BufReader::new(
+        File::open(cert_path).with_context(|| format!("reading TLS cert at {}", cert_path.display()))?,
+    );
     let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
         rustls_pemfile::certs(&mut cert_reader).flatten().collect();
 
-    let mut key_reader = BufReader::new(File::open(key_path)?);
+    let mut key_reader = BufReader::new(
+        File::open(key_path).with_context(|| format!("reading TLS key at {}", key_path.display()))?,
+    );
     let key = rustls_pemfile::private_key(&mut key_reader)?
         .ok_or(anyhow!("No Private Key"))?;
 

--- a/common/src/server/log.rs
+++ b/common/src/server/log.rs
@@ -1,52 +1,126 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Severity for the server log macros, ordered low→high. The active
+/// threshold ([`init`]) suppresses anything below it.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[repr(u8)]
+pub enum Level {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+}
+
+/// Active threshold; defaults to Info until [`init`] runs.
+static LEVEL: AtomicU8 = AtomicU8::new(Level::Info as u8);
+
+/// True if `level` should be emitted at the current threshold.
+#[inline]
+pub fn enabled(level: Level) -> bool {
+    (level as u8) >= LEVEL.load(Ordering::Relaxed)
+}
+
+fn parse(s: &str) -> Option<Level> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "trace" => Some(Level::Trace),
+        "debug" => Some(Level::Debug),
+        "info" => Some(Level::Info),
+        "warn" | "warning" => Some(Level::Warn),
+        "error" => Some(Level::Error),
+        _ => None,
+    }
+}
+
+/// Resolve the threshold: `PZ_LOG` env wins, then the config value, else Info.
+pub fn init(config_level: Option<&str>) {
+    let env_level = std::env::var("PZ_LOG").ok();
+    let chosen = env_level
+        .as_deref()
+        .and_then(parse)
+        .or_else(|| config_level.and_then(parse))
+        .unwrap_or(Level::Info);
+    LEVEL.store(chosen as u8, Ordering::Relaxed);
+}
+
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => {{
-        println!(
-            "\x1b[48;5;235m\x1b[38;5;39m DEBUG \x1b[0m\x1b[48;5;235m{} \x1b[0m",
-            format!($($arg)*)
-        );
+        if $crate::server::log::enabled($crate::server::log::Level::Debug) {
+            println!(
+                "\x1b[48;5;235m\x1b[38;5;39m DEBUG \x1b[0m\x1b[48;5;235m{} \x1b[0m",
+                format!($($arg)*)
+            );
+        }
     }};
 }
 
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)*) => {{
-        println!(
-            "\x1b[48;5;236m\x1b[38;5;34m INFO  \x1b[0m\x1b[48;5;236m{} \x1b[0m",
-            format!($($arg)*)
-        );
+        if $crate::server::log::enabled($crate::server::log::Level::Info) {
+            println!(
+                "\x1b[48;5;236m\x1b[38;5;34m INFO  \x1b[0m\x1b[48;5;236m{} \x1b[0m",
+                format!($($arg)*)
+            );
+        }
     }};
 }
 
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)*) => {{
-        println!(
-            "\x1b[48;5;58m\x1b[38;5;220m WARN  \x1b[0m\
+        if $crate::server::log::enabled($crate::server::log::Level::Warn) {
+            println!(
+                "\x1b[48;5;58m\x1b[38;5;220m WARN  \x1b[0m\
 \x1b[48;5;58m\x1b[38;5;15m{} \x1b[0m",
-            format!($($arg)*)
-        );
+                format!($($arg)*)
+            );
+        }
     }};
 }
 
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)*) => {{
-        eprintln!(
-            "\x1b[48;5;52m\x1b[38;5;196m ERROR \x1b[0m\
+        if $crate::server::log::enabled($crate::server::log::Level::Error) {
+            eprintln!(
+                "\x1b[48;5;52m\x1b[38;5;196m ERROR \x1b[0m\
 \x1b[48;5;52m\x1b[38;5;15m{} \x1b[0m",
-            format!($($arg)*)
-        );
+                format!($($arg)*)
+            );
+        }
     }};
 }
 
 #[macro_export]
 macro_rules! trace {
     ($($arg:tt)*) => {{
-        println!(
-            "\x1b[48;5;234m\x1b[38;5;244m TRACE \x1b[0m\
+        if $crate::server::log::enabled($crate::server::log::Level::Trace) {
+            println!(
+                "\x1b[48;5;234m\x1b[38;5;244m TRACE \x1b[0m\
 \x1b[48;5;234m\x1b[38;5;245m{} \x1b[0m",
-            format!($($arg)*)
-        );
+                format!($($arg)*)
+            );
+        }
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn level_ordering_gates_correctly() {
+        LEVEL.store(Level::Warn as u8, Ordering::Relaxed);
+        assert!(!enabled(Level::Info));
+        assert!(enabled(Level::Warn));
+        assert!(enabled(Level::Error));
+    }
+
+    #[test]
+    fn parse_is_case_insensitive() {
+        assert_eq!(parse("DEBUG"), Some(Level::Debug));
+        assert_eq!(parse("nope"), None);
+    }
 }

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -54,8 +54,8 @@ x509-parser = "0.18"
 
 # ---------------------------------------------------------------------------
 # Debian packaging (`cargo deb`) → `pzrelay_<version>_<arch>.deb`.
-# Binary installs as /usr/bin/pzrelay; config + CA under /etc/pzrelay;
-# runtime keys + RocksDB under /var/lib/pzrelay (service user `pzrelay`).
+# Binary installs as /usr/bin/pzrelay; config + CA + keys + cert under
+# /etc/promtuz; RocksDB under /var/lib/pzrelay (service user `pzrelay`).
 # ---------------------------------------------------------------------------
 [package.metadata.deb]
 name = "pzrelay"
@@ -70,9 +70,9 @@ depends = "libc6 (>= 2.28)"
 extended-description = "Promtuz relay node: Kademlia DHT, client auth, presence + MLS handshake replication, store-and-forward."
 assets = [
     ["target/release/relay", "usr/bin/pzrelay", "755"],
-    ["pkg/relay.toml", "etc/pzrelay/relay.toml", "644"],
-    ["../certs/root_ca.pem", "etc/pzrelay/ca.pem", "644"],
+    ["pkg/relay.toml", "etc/promtuz/relay.toml", "644"],
+    ["../certs/root_ca.pem", "etc/promtuz/ca.pem", "644"],
     ["pkg/pzrelay.service", "lib/systemd/system/pzrelay.service", "644"],
 ]
-conf-files = ["/etc/pzrelay/relay.toml"]
+conf-files = ["/etc/promtuz/relay.toml"]
 maintainer-scripts = "pkg/scripts/"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -37,6 +37,7 @@ rustls.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 crossterm.workspace = true
+clap.workspace = true
 serde_bytes.workspace = true
 ed25519-dalek.workspace = true
 rustls-pemfile.workspace = true

--- a/relay/README.md
+++ b/relay/README.md
@@ -31,15 +31,24 @@ packages on your system.
 
 ## Configure
 
-Edit `/etc/pzrelay/relay.toml` — set the resolver seed key and your box's
-public address. Edits survive `apt upgrade` (it's a dpkg conffile).
+Edit `/etc/promtuz/relay.toml` — set the resolver seed key and your box's
+public address. Edits survive `apt upgrade` (it's a dpkg conffile). Log
+verbosity is `[log] level` (or the `PZ_LOG` env): `trace|debug|info|warn|error`.
 
-## Provision identity (enrollment)
+## Enroll (mint the cert)
 
 A relay is permissioned: it needs a cert signed by the Promtuz RootCA before it
-can serve. Today that material is obtained out-of-band and placed in
-`/var/lib/pzrelay/` as `node.crt` + `node.key` (automated enrollment is in
-progress). The Ed25519 identity key auto-generates on first start if absent.
+can serve. The flow is self-service and the private key never leaves the box:
+
+1. Start the relay (below). On first boot it generates its single Ed25519 key
+   (`/etc/promtuz/keys/relay.key` — identity **and** TLS), writes a CSR to
+   `/etc/promtuz/relay.csr`, logs what to do, and **waits** (no crash-loop).
+2. Copy `relay.csr` to your CA box and sign it: `certgen sign relay.csr` →
+   `relay.crt`.
+3. Drop the signed cert at `/etc/promtuz/certs/relay.crt`. The relay is watching
+   — it picks the cert up, deletes the CSR, and starts serving.
+
+The cert certifies the relay's identity key, so `CN = relay_id`.
 
 ## Run
 
@@ -65,9 +74,11 @@ Single `edge` channel for now — the project is pre-production. A vetted
 | What | Where |
 |------|-------|
 | binary | `/usr/bin/pzrelay` |
-| config | `/etc/pzrelay/relay.toml` (conffile) |
-| RootCA | `/etc/pzrelay/ca.pem` |
-| data + keys | `/var/lib/pzrelay/` (RocksDB, identity/TLS keys) |
+| config | `/etc/promtuz/relay.toml` (conffile) |
+| RootCA | `/etc/promtuz/ca.pem` |
+| key | `/etc/promtuz/keys/relay.key` (identity + TLS, 0600) |
+| cert | `/etc/promtuz/certs/relay.crt` |
+| database | `/var/lib/pzrelay/` (RocksDB) |
 | logs | `journalctl -u pzrelay` |
 | version | `pzrelay --version` |
 

--- a/relay/config.toml.example
+++ b/relay/config.toml.example
@@ -1,0 +1,31 @@
+# Dev config for running the relay from the repo: `cargo run -p relay`.
+# Copy to `config.toml` (gitignored / kept local) and adjust paths.
+# Production uses /etc/promtuz — see pkg/relay.toml.
+
+[network]
+# Local bind. Use 0.0.0.0:<port>; the canonical relay port is 40432.
+address = "0.0.0.0:40432"
+
+# One Ed25519 key = identity (signs RelayHello, derives relay_id) + TLS server
+# key. Auto-generated 0o600 on first boot if missing.
+key_path = "cert/relay.key"
+
+# CA-issued cert certifying key_path (CN/SAN = relay_id). Provisioned by
+# enrollment: first boot writes relay.csr; sign it (`certgen sign`) and drop
+# the cert here.
+cert_path = "cert/relay.crt"
+
+root_ca_path = "cert/root_ca.pem"
+
+[log]
+# trace|debug|info|warn|error ; the PZ_LOG env var overrides this.
+level = "info"
+
+[[resolver.seed]]
+# Resolver identity pubkey (hex) + reachable address (host[:port], port
+# defaults to 40433). Replace with your resolver's IPK.
+key = "55eca4054c27ff7e8d613f876cbed9c9ac72f7737af520511663eba4f6ce1d1b"
+addr = "resolver.promtuz.dev"
+
+[dht]
+enabled = true

--- a/relay/pkg/pzrelay.service
+++ b/relay/pkg/pzrelay.service
@@ -8,13 +8,14 @@ Wants=network-online.target
 Type=simple
 User=pzrelay
 Group=pzrelay
-ExecStart=/usr/bin/pzrelay /etc/pzrelay/relay.toml
+ExecStart=/usr/bin/pzrelay --config /etc/promtuz/relay.toml
 WorkingDirectory=/var/lib/pzrelay
 Restart=on-failure
 RestartSec=2
 
-# Least-privilege hardening. /etc + /usr are read-only; the only writable
-# path is the state dir (RocksDB + runtime-provisioned keys).
+# Least-privilege hardening. /usr stays read-only; the writable paths are the
+# RocksDB state dir and /etc/promtuz (the relay generates its key, writes a
+# CSR, and reads the enrolled cert there).
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
@@ -23,8 +24,8 @@ ProtectControlGroups=true
 ProtectKernelTunables=true
 RestrictAddressFamilies=AF_INET AF_INET6
 StateDirectory=pzrelay
-ConfigurationDirectory=pzrelay
-ReadWritePaths=/var/lib/pzrelay
+ConfigurationDirectory=promtuz
+ReadWritePaths=/var/lib/pzrelay /etc/promtuz
 
 [Install]
 WantedBy=multi-user.target

--- a/relay/pkg/relay.toml
+++ b/relay/pkg/relay.toml
@@ -1,25 +1,31 @@
-# Promtuz relay configuration. This file is a dpkg conffile: your edits survive
-# `apt upgrade`. Provision node.crt / node.key into /var/lib/pzrelay before
-# starting (see enrollment), then `systemctl enable --now pzrelay`.
+# Promtuz relay config. dpkg conffile: your edits survive `apt upgrade`.
+# On first start the relay generates /etc/promtuz/keys/relay.key, writes a CSR
+# to /etc/promtuz/relay.csr, and waits. Sign it (`certgen sign`) and drop the
+# cert at /etc/promtuz/certs/relay.crt — it then starts automatically.
 
 [network]
-# Bind address. 0.0.0.0:<port> is fine on a single-public-IP box. If the box is
-# multi-homed, bind your PUBLIC ip:port so the source address the resolver vends
-# to other relays is deterministically dialable. Default relay port is 40432.
+# Bind. 0.0.0.0:<port> is fine on a single-public-IP box. Default port 40432.
 address = "0.0.0.0:40432"
 
-# TLS + identity material. The cert/key are issued at enrollment; the
-# identity key auto-generates (0600) on first boot if absent.
-cert_path = "/var/lib/pzrelay/node.crt"
-key_path = "/var/lib/pzrelay/node.key"
-identity_key_path = "/var/lib/pzrelay/identity.key"
+# One Ed25519 key = identity (signs RelayHello, derives relay_id) + TLS server
+# key. Auto-generated 0600 on first boot if absent.
+key_path = "/etc/promtuz/keys/relay.key"
+
+# CA-issued cert certifying key_path (CN/SAN = relay_id), via enrollment.
+cert_path = "/etc/promtuz/certs/relay.crt"
 
 # Production RootCA public cert, shipped with the package.
-root_ca_path = "/etc/pzrelay/ca.pem"
+root_ca_path = "/etc/promtuz/ca.pem"
+
+# Restart in place when this file changes (default off).
+# watch_reload = true
+
+[log]
+# trace|debug|info|warn|error ; the PZ_LOG env var overrides this.
+level = "info"
 
 [[resolver.seed]]
-# Resolver identity pubkey (hex) + reachable address (hostname or IP; the port
-# is optional and defaults to 40433). Replace the key with your resolver's IPK.
+# Resolver identity pubkey (hex) + address (host[:port]; port defaults 40433).
 key = "55ECA4054C27FF7E8D613F876CBED9C9AC72F7737AF520511663EBA4F6CE1D1B"
 addr = "resolver.promtuz.dev"
 

--- a/relay/pkg/scripts/postinst
+++ b/relay/pkg/scripts/postinst
@@ -7,13 +7,18 @@ if ! getent passwd pzrelay >/dev/null 2>&1; then
     adduser --system --group --no-create-home --home /var/lib/pzrelay pzrelay
 fi
 
+# Writable homes for the generated key + the enrolled cert.
+install -d -o pzrelay -g pzrelay -m 0700 /etc/promtuz/keys
+install -d -o pzrelay -g pzrelay -m 0755 /etc/promtuz/certs
+
 systemctl daemon-reload >/dev/null 2>&1 || true
 
 cat <<'EOF'
 pzrelay installed. Next:
-  1. edit  /etc/pzrelay/relay.toml   (resolver seed key + your public address)
-  2. provision node.crt / node.key into /var/lib/pzrelay   (enrollment)
-  3. systemctl enable --now pzrelay
+  1. systemctl enable --now pzrelay        # generates the key, writes the CSR, waits
+  2. certgen sign /etc/promtuz/relay.csr        (on your CA box)
+  3. copy the signed cert to /etc/promtuz/certs/relay.crt   # starts automatically
+Edit /etc/promtuz/relay.toml for the resolver seed + bind address.
 EOF
 
 exit 0

--- a/relay/src/cli.rs
+++ b/relay/src/cli.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("PZ_GIT_SHA"), ")");
+
+/// Promtuz relay node CLI.
+#[derive(Parser, Debug)]
+#[command(name = "pzrelay", version = VERSION, about = "Promtuz relay node")]
+pub struct Cli {
+    /// Path to the config file.
+    #[arg(short, long, default_value = "/etc/promtuz/relay.toml")]
+    pub config: PathBuf,
+}
+
+impl Cli {
+    /// Parse argv (handles `--version` / `--help` and exits as clap does).
+    pub fn get() -> Self {
+        Self::parse()
+    }
+}

--- a/relay/src/dht/sync/mod.rs
+++ b/relay/src/dht/sync/mod.rs
@@ -369,6 +369,9 @@ pub(crate) async fn run_scheduler(dht: Arc<Dht>, cancel: CancellationToken) {
     //   bootstrap RPC, not just emits a warning.
     let mut bootstrap_backoff_ms = BOOTSTRAP_RETRY_BASE_MS;
     let mut last_bootstrap_attempt_ms: u64 = 0;
+    // Edge-trigger the sparse-table notice: log on entering/leaving the
+    // sparse state, not on every tick.
+    let mut was_sparse = false;
 
     loop {
         tokio::select! {
@@ -387,63 +390,41 @@ pub(crate) async fn run_scheduler(dht: Arc<Dht>, cancel: CancellationToken) {
                 // on `Dht` so unit-test fixtures (no resolver link)
                 // skip this branch silently. See `Dht::attach_resolver`.
                 let known = dht.routing.read().total_known();
-                if known < BOOTSTRAP_RETRY_THRESHOLD {
+                let sparse = known < BOOTSTRAP_RETRY_THRESHOLD;
+                if sparse && !was_sparse {
+                    warn!("DHT routing table sparse ({known} < {BOOTSTRAP_RETRY_THRESHOLD}); retrying bootstrap");
+                } else if !sparse && was_sparse {
+                    info!("DHT routing table recovered ({known} >= {BOOTSTRAP_RETRY_THRESHOLD})");
+                }
+                was_sparse = sparse;
+                if sparse {
                     let now = now_ms();
                     if now.saturating_sub(last_bootstrap_attempt_ms) >= bootstrap_backoff_ms {
                         last_bootstrap_attempt_ms = now;
 
-                        // Snapshot the resolver handle out of the
-                        // RwLock so the lock isn't held across the
-                        // `await`. The handle itself is cheap to
-                        // clone — internally an `Arc<RwLock<Option<Connection>>>`.
+                        // Snapshot the resolver handle out of the RwLock so the
+                        // lock isn't held across the `await`.
                         let handle_opt = dht.resolver.read().clone();
                         match handle_opt {
-                            Some(handle) => {
-                                info!(
-                                    "DHT scheduler: routing table sparse ({known} < {}); retrying bootstrap (backoff {}ms)",
-                                    BOOTSTRAP_RETRY_THRESHOLD,
-                                    bootstrap_backoff_ms,
-                                );
-                                match bootstrap(dht.clone(), handle).await {
-                                    Ok(state) => {
-                                        info!(
-                                            "DHT scheduler: bootstrap retry succeeded (state {state:?}); resetting backoff"
-                                        );
-                                        bootstrap_backoff_ms = BOOTSTRAP_RETRY_BASE_MS;
-                                    },
-                                    // EmptyRegistry is the legitimate
-                                    // brand-new-network case — log at
-                                    // info, keep backoff at base so a
-                                    // peer joining shortly after lets
-                                    // us re-converge promptly.
-                                    Err(BootstrapError::EmptyRegistry) => {
-                                        info!(
-                                            "DHT scheduler: bootstrap retry got empty registry (new network?); holding base backoff"
-                                        );
-                                        bootstrap_backoff_ms = BOOTSTRAP_RETRY_BASE_MS;
-                                    },
-                                    Err(e) => {
-                                        warn!(
-                                            "DHT scheduler: bootstrap retry failed: {e}; doubling backoff"
-                                        );
-                                        bootstrap_backoff_ms = (bootstrap_backoff_ms * 2)
-                                            .min(BOOTSTRAP_RETRY_MAX_BACKOFF_MS);
-                                    },
-                                }
+                            Some(handle) => match bootstrap(dht.clone(), handle).await {
+                                Ok(state) => {
+                                    info!("DHT bootstrap retry succeeded (state {state:?})");
+                                    bootstrap_backoff_ms = BOOTSTRAP_RETRY_BASE_MS;
+                                },
+                                // Brand-new-network case — hold base backoff so a
+                                // peer joining shortly after lets us re-converge.
+                                Err(BootstrapError::EmptyRegistry) => {
+                                    bootstrap_backoff_ms = BOOTSTRAP_RETRY_BASE_MS;
+                                },
+                                Err(e) => {
+                                    warn!("DHT bootstrap retry failed: {e}; backing off");
+                                    bootstrap_backoff_ms =
+                                        (bootstrap_backoff_ms * 2).min(BOOTSTRAP_RETRY_MAX_BACKOFF_MS);
+                                },
                             },
                             None => {
-                                // No resolver handle attached — this
-                                // is the unit-test path, or a relay
-                                // that never wired one in. Log once per
-                                // backoff window and double the
-                                // backoff so we don't flood logs.
-                                info!(
-                                    "DHT scheduler: routing table sparse ({known} < {}); no resolver handle attached, skipping retry (next backoff {}ms)",
-                                    BOOTSTRAP_RETRY_THRESHOLD,
-                                    bootstrap_backoff_ms,
-                                );
-                                bootstrap_backoff_ms = (bootstrap_backoff_ms * 2)
-                                    .min(BOOTSTRAP_RETRY_MAX_BACKOFF_MS);
+                                bootstrap_backoff_ms =
+                                    (bootstrap_backoff_ms * 2).min(BOOTSTRAP_RETRY_MAX_BACKOFF_MS);
                             },
                         }
                     }

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -33,6 +33,9 @@ async fn main() -> Result<()> {
     // if not enrolled), so the endpoint is only built with usable TLS material.
     let csr_path = cli.config.with_extension("csr");
     common::node::enroll::ensure_enrolled(&cfg.network, &csr_path, "relay").await?;
+    if cfg.network.watch_reload {
+        common::node::enroll::spawn_config_reload(cli.config.clone());
+    }
 
     // `shutdown` is the legacy `watch` channel still consumed by
     // `ResolverLink`; `cancel` is the unified token observed by every

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -29,6 +29,7 @@ async fn main() -> Result<()> {
     }
 
     let cfg = AppConfig::load(true);
+    common::server::log::init(cfg.log.level.as_deref());
     info!("pzrelay {} ({})", env!("CARGO_PKG_VERSION"), env!("PZ_GIT_SHA"));
 
     // `shutdown` is the legacy `watch` channel still consumed by

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -29,6 +29,11 @@ async fn main() -> Result<()> {
     common::server::log::init(cfg.log.level.as_deref());
     info!("pzrelay {} ({})", env!("CARGO_PKG_VERSION"), env!("PZ_GIT_SHA"));
 
+    // Hold here until we have a valid cert for our key (writes a CSR + waits
+    // if not enrolled), so the endpoint is only built with usable TLS material.
+    let csr_path = cli.config.with_extension("csr");
+    common::node::enroll::ensure_enrolled(&cfg.network, &csr_path, "relay").await?;
+
     // `shutdown` is the legacy `watch` channel still consumed by
     // `ResolverLink`; `cancel` is the unified token observed by every
     // per-connection task spawned via `Acceptor`. Both fire together on

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -14,6 +14,7 @@ use crate::quic::resolver_link::ResolverLink;
 use crate::relay::Relay;
 use crate::util::config::AppConfig;
 
+mod cli;
 mod dht;
 mod quic;
 mod relay;
@@ -22,13 +23,9 @@ mod util;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // `--version` / `-V`: report and exit before touching config or the runtime.
-    if std::env::args().skip(1).any(|a| a == "--version" || a == "-V") {
-        println!("pzrelay {} ({})", env!("CARGO_PKG_VERSION"), env!("PZ_GIT_SHA"));
-        return Ok(());
-    }
+    let cli = cli::Cli::get();
 
-    let cfg = AppConfig::load(true);
+    let cfg = AppConfig::load(&cli.config, true);
     common::server::log::init(cfg.log.level.as_deref());
     info!("pzrelay {} ({})", env!("CARGO_PKG_VERSION"), env!("PZ_GIT_SHA"));
 

--- a/relay/src/relay/mod.rs
+++ b/relay/src/relay/mod.rs
@@ -103,7 +103,7 @@ impl Relay {
     fn endpoint(cfg: &AppConfig, node_signing: &SigningKey) -> Endpoint {
         use ProtoRole as PR;
 
-        graceful!(setup_crypto_provider(), "CRYPTO_ERR:");
+        graceful!(setup_crypto_provider(), "installing the crypto provider");
 
         let server_cfg = graceful!(
             build_server_cfg_with_alpn_split(
@@ -112,10 +112,10 @@ impl Relay {
                 node_signing.clone(),
                 &[PR::Resolver, PR::Relay, PR::Peer, PR::Client],
             ),
-            "SERVER_CFG_ERR:"
+            "building the TLS server config"
         );
 
-        let endpoint = graceful!(Endpoint::server(server_cfg, cfg.network.address), "QUIC_ERR:");
+        let endpoint = graceful!(Endpoint::server(server_cfg, cfg.network.address), "starting the QUIC endpoint");
         if let Ok(addr) = endpoint.local_addr() {
             info!("relay listening at QUIC({:?})", addr);
         }
@@ -130,22 +130,22 @@ impl Relay {
 
         let mut endpoint = Self::endpoint(&cfg, &keys.signing);
 
-        let roots = graceful!(load_root_ca(&cfg.network.root_ca_path), "CA_ERR:");
+        let roots = graceful!(load_root_ca(&cfg.network.root_ca_path), "loading the root CA");
 
         let client_cfg =
-            Arc::new(graceful!(build_client_cfg(ProtoRole::Relay, &roots), "CLIENT_CFG_ERR:"));
+            Arc::new(graceful!(build_client_cfg(ProtoRole::Relay, &roots), "building the QUIC client config"));
         // peer/1 is the key-as-identity trust domain (self-signed NodeKey
         // certs, pinned to the dialed NodeId post-handshake), not the CA
         // hierarchy — so it gets its own verifier, not build_client_cfg.
         let peer_client_cfg =
-            Arc::new(graceful!(crate::dht::peer_dial::build_peer_client_cfg(), "PEER_CFG_ERR:"));
+            Arc::new(graceful!(crate::dht::peer_dial::build_peer_client_cfg(), "building the peer/1 client config"));
 
         endpoint.set_default_client_config((*client_cfg).clone());
 
         // Single shared `Arc<DB>` so the DHT replica and the message
         // queue point at the same on-disk store but live in separate
         // column families.
-        let rocks = Arc::new(graceful!(rocksdb(), "failed to setup rocksdb"));
+        let rocks = Arc::new(graceful!(rocksdb(), "opening the RocksDB store"));
         // `clients` is `Arc<RwLock<...>>` (not a bare `RwLock`) so the
         // inner map can be cloned-by-Arc into `Dht.clients` for the
         // home-side `Forward` handler.

--- a/relay/src/relay/mod.rs
+++ b/relay/src/relay/mod.rs
@@ -24,16 +24,12 @@ use crate::dht::Dht;
 use crate::util::config::AppConfig;
 use crate::util::rocksdb::rocksdb;
 
-/// Long-term Ed25519 *identity* keypair for this relay.
+/// The relay's single Ed25519 keypair: identity **and** TLS.
 ///
-/// This is **not** the TLS server key. The TLS key (loaded directly by
-/// `build_server_cfg` from `cfg.network.key_path`) lives only inside
-/// rustls/aws-lc-rs and never touches the application layer. The identity
-/// key here is what signs application-layer messages on this relay's
-/// behalf — currently `RelayHello` to the resolver — and is what derives
-/// the public-facing `relay_id`. Splitting the two trust roots means a
-/// TLS-layer key disclosure does not turn into a permanent identity
-/// compromise.
+/// One key signs application-layer messages (`RelayHello` to the resolver),
+/// derives the public-facing `relay_id`, backs the in-memory `peer/1`
+/// self-signed cert, and is the key the CA-issued cert certifies. Loaded
+/// from `key_path`; auto-created `0o600` on first boot if absent.
 #[derive(Debug)]
 pub struct RelayKeys {
     pub signing: SigningKey,
@@ -42,9 +38,7 @@ pub struct RelayKeys {
 
 impl RelayKeys {
     fn from_cfg(cfg: &AppConfig) -> Result<Self, ()> {
-        // Loaded from `identity_key_path`, distinct from `key_path` (which
-        // is the TLS server key). The file is auto-created on first run.
-        let secret = secret_from_key_or_create(&cfg.network.identity_key_path)?;
+        let secret = secret_from_key_or_create(&cfg.network.key_path)?;
         let public = secret.verifying_key();
 
         Ok(Self { signing: secret, public })

--- a/relay/src/util/config.rs
+++ b/relay/src/util/config.rs
@@ -1,10 +1,9 @@
 use std::fs;
 use std::io::Write;
-use std::net::SocketAddr;
 use std::path::Path;
-use std::path::PathBuf;
 use std::process;
 
+use common::node::config::NetworkConfig;
 use common::node::config::NodeConfig;
 use serde::Deserialize;
 
@@ -31,34 +30,6 @@ pub struct AppConfig {
 pub struct LogConfig {
     /// trace|debug|info|warn|error. `PZ_LOG` env overrides. Default: info.
     pub level: Option<String>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct NetworkConfig {
-    /// Local Address of relay where endpoint will bind
-    ///
-    /// Not to be confused with public address
-    pub address: SocketAddr,
-    pub cert_path: PathBuf,
-
-    /// PKCS#8 PEM private key used as the **TLS server key**. This is the
-    /// material rustls hands to its TLS handshake signer; a key compromise
-    /// here is bounded to the lifetime of the issued cert.
-    pub key_path: PathBuf,
-
-    /// PKCS#8 PEM Ed25519 private key used as this relay's **long-term
-    /// identity key**, separate from the TLS server key. Anything signed
-    /// "as this relay" (e.g. `RelayHello` to the resolver) uses this key.
-    ///
-    /// Kept separate from `key_path` so a TLS-layer compromise (memory
-    /// disclosure in rustls/aws-lc-rs, a leaked cert key, …) does not
-    /// silently turn into a permanent identity compromise.
-    ///
-    /// The file is auto-generated with `0o600` perms on first boot if it
-    /// does not exist; treat it like an SSH host key thereafter.
-    pub identity_key_path: PathBuf,
-
-    pub root_ca_path: PathBuf,
 }
 
 impl AppConfig {

--- a/relay/src/util/config.rs
+++ b/relay/src/util/config.rs
@@ -22,6 +22,16 @@ pub struct AppConfig {
     /// the pre-DHT code path. The default is **disabled**.
     #[serde(default)]
     pub dht: DhtConfig,
+
+    /// Optional logging block. Absent → info. `PZ_LOG` env overrides.
+    #[serde(default)]
+    pub log: LogConfig,
+}
+
+#[derive(Deserialize, Debug, Default)]
+pub struct LogConfig {
+    /// trace|debug|info|warn|error. `PZ_LOG` env overrides. Default: info.
+    pub level: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/relay/src/util/config.rs
+++ b/relay/src/util/config.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::fs;
 use std::io::Write;
 use std::net::SocketAddr;
@@ -63,17 +62,14 @@ pub struct NetworkConfig {
 }
 
 impl AppConfig {
-    pub fn load(cls: bool) -> Self {
+    pub fn load(path: &Path, cls: bool) -> Self {
         if cls {
             print!("\x1B[2J\x1B[1;1H");
             std::io::stdout().flush().ok();
         }
 
-        let path = env::args().nth(1).unwrap_or_else(|| "config.toml".into());
-        let path = Path::new(&path);
-
         if !path.exists() {
-            common::error!("config.toml not found: {}", path.display());
+            common::error!("config not found: {}", path.display());
             std::process::exit(1);
         }
 

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -18,6 +18,7 @@ tokio.workspace = true
 rand.workspace = true
 rustls-pemfile.workspace = true
 ed25519-dalek.workspace = true
+clap.workspace = true
 parking_lot = "0.12.5"
 # Per-source-IP accept-side rate limiter. Token bucket with automatic state
 # expiry (no per-IP entry kept forever).

--- a/resolver/Cargo.toml
+++ b/resolver/Cargo.toml
@@ -26,7 +26,7 @@ governor = "0.7"
 
 # ---------------------------------------------------------------------------
 # Debian packaging (`cargo deb`) → `pzresolver_<version>_<arch>.deb`.
-# Binary installs as /usr/bin/pzresolver; config + CA under /etc/pzresolver.
+# Binary installs as /usr/bin/pzresolver; config + CA + keys + cert under /etc/promtuz.
 # The resolver is stateless (in-memory) — no /var/lib, nothing written at run.
 # Build via ./scripts/build-deb.sh resolver (cargo-zigbuild → libc6 only).
 # ---------------------------------------------------------------------------
@@ -40,9 +40,9 @@ depends = "libc6 (>= 2.28)"
 extended-description = "Promtuz resolver: stateless relay discovery service."
 assets = [
     ["target/release/resolver", "usr/bin/pzresolver", "755"],
-    ["pkg/resolver.toml", "etc/pzresolver/resolver.toml", "644"],
-    ["../certs/root_ca.pem", "etc/pzresolver/ca.pem", "644"],
+    ["pkg/resolver.toml", "etc/promtuz/resolver.toml", "644"],
+    ["../certs/root_ca.pem", "etc/promtuz/ca.pem", "644"],
     ["pkg/pzresolver.service", "lib/systemd/system/pzresolver.service", "644"],
 ]
-conf-files = ["/etc/pzresolver/resolver.toml"]
+conf-files = ["/etc/promtuz/resolver.toml"]
 maintainer-scripts = "pkg/scripts/"

--- a/resolver/README.md
+++ b/resolver/README.md
@@ -22,19 +22,23 @@ echo "deb [signed-by=/etc/apt/keyrings/promtuz.asc] https://apt.promtuz.dev edge
 sudo apt update && sudo apt install pzresolver
 ```
 
-## Configure + run
+## Enroll + run
+
+Same self-service flow as the relay, and the private key never leaves the box.
+On first boot the resolver generates its single Ed25519 key
+(`/etc/promtuz/keys/resolver.key` — its pubkey is the resolver IPK relays seed),
+writes `/etc/promtuz/resolver.csr`, and waits.
 
 ```sh
-# Place the resolver's cert/key (its node.key pubkey is the resolver IPK that
-# relays seed in their configs):
-sudo cp node.crt node.key /etc/pzresolver/
-
-# Check the bind address:
-sudoedit /etc/pzresolver/resolver.toml
-
-sudo systemctl enable --now pzresolver
+sudo systemctl enable --now pzresolver                  # generates key, writes CSR, waits
+# on your CA box:
+certgen sign resolver.csr
+# back on the resolver box:
+sudo cp resolver.crt /etc/promtuz/certs/resolver.crt    # it starts automatically
 journalctl -u pzresolver -f
 ```
+
+Check the bind address in `/etc/promtuz/resolver.toml` (a dpkg conffile).
 
 ## Update
 
@@ -47,8 +51,10 @@ sudo apt update && sudo apt upgrade     # config preserved
 | What | Where |
 |------|-------|
 | binary | `/usr/bin/pzresolver` |
-| config | `/etc/pzresolver/resolver.toml` (conffile) |
-| certs + CA | `/etc/pzresolver/` (`node.crt`, `node.key`, `ca.pem`) |
+| config | `/etc/promtuz/resolver.toml` (conffile) |
+| RootCA | `/etc/promtuz/ca.pem` |
+| key | `/etc/promtuz/keys/resolver.key` (identity + TLS, 0600) |
+| cert | `/etc/promtuz/certs/resolver.crt` |
 | logs | `journalctl -u pzresolver` |
 | version | `pzresolver --version` |
 

--- a/resolver/pkg/pzresolver.service
+++ b/resolver/pkg/pzresolver.service
@@ -8,12 +8,12 @@ Wants=network-online.target
 Type=simple
 User=pzresolver
 Group=pzresolver
-ExecStart=/usr/bin/pzresolver /etc/pzresolver/resolver.toml
+ExecStart=/usr/bin/pzresolver --config /etc/promtuz/resolver.toml
 Restart=on-failure
 RestartSec=2
 
-# Least-privilege hardening. The resolver is stateless (in-memory) and writes
-# nothing, so the whole filesystem can stay read-only.
+# Least-privilege hardening. /usr stays read-only; /etc/promtuz is writable so
+# the resolver can generate its key, write a CSR, and read the enrolled cert.
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
@@ -21,7 +21,8 @@ PrivateTmp=true
 ProtectControlGroups=true
 ProtectKernelTunables=true
 RestrictAddressFamilies=AF_INET AF_INET6
-ConfigurationDirectory=pzresolver
+ConfigurationDirectory=promtuz
+ReadWritePaths=/etc/promtuz
 
 [Install]
 WantedBy=multi-user.target

--- a/resolver/pkg/resolver.toml
+++ b/resolver/pkg/resolver.toml
@@ -1,15 +1,21 @@
-# pzresolver configuration. This file is a dpkg conffile: your edits survive
-# `apt upgrade`. Provision node.crt / node.key into /etc/pzresolver before
-# starting, then `systemctl enable --now pzresolver`.
+# pzresolver config. dpkg conffile: your edits survive `apt upgrade`. Same
+# enrollment flow as the relay: the key auto-generates, a CSR is written to
+# /etc/promtuz/resolver.csr — sign it and drop the cert to start.
 
 [network]
-# Bind address — the port relays dial. 0.0.0.0 listens on all interfaces.
+# Bind — the port relays dial. 0.0.0.0 listens on all interfaces.
 address = "0.0.0.0:40433"
 
-# TLS + identity material. The resolver's node.key doubles as its identity key;
-# its pubkey is the resolver IPK that relays seed in their configs.
-cert_path = "/etc/pzresolver/node.crt"
-key_path = "/etc/pzresolver/node.key"
+# One Ed25519 key = the resolver's identity (its pubkey is the IPK relays seed)
+# + TLS server key. Auto-generated 0600 on first boot if absent.
+key_path = "/etc/promtuz/keys/resolver.key"
+
+# CA-issued cert certifying key_path, via enrollment.
+cert_path = "/etc/promtuz/certs/resolver.crt"
 
 # Production RootCA public cert, shipped with the package.
-root_ca_path = "/etc/pzresolver/ca.pem"
+root_ca_path = "/etc/promtuz/ca.pem"
+
+[log]
+# trace|debug|info|warn|error ; the PZ_LOG env var overrides this.
+level = "info"

--- a/resolver/pkg/scripts/postinst
+++ b/resolver/pkg/scripts/postinst
@@ -7,13 +7,17 @@ if ! getent passwd pzresolver >/dev/null 2>&1; then
     adduser --system --group --no-create-home --home /nonexistent pzresolver
 fi
 
+# Writable homes for the generated key + the enrolled cert.
+install -d -o pzresolver -g pzresolver -m 0700 /etc/promtuz/keys
+install -d -o pzresolver -g pzresolver -m 0755 /etc/promtuz/certs
+
 systemctl daemon-reload >/dev/null 2>&1 || true
 
 cat <<'EOF'
 pzresolver installed. Next:
-  1. provision node.crt / node.key into /etc/pzresolver
-  2. check /etc/pzresolver/resolver.toml (bind address)
-  3. systemctl enable --now pzresolver
+  1. systemctl enable --now pzresolver     # generates the key, writes the CSR, waits
+  2. certgen sign /etc/promtuz/resolver.csr     (on your CA box)
+  3. copy the signed cert to /etc/promtuz/certs/resolver.crt   # starts automatically
 EOF
 
 exit 0

--- a/resolver/src/cli.rs
+++ b/resolver/src/cli.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("PZ_GIT_SHA"), ")");
+
+/// Promtuz resolver CLI.
+#[derive(Parser, Debug)]
+#[command(name = "pzresolver", version = VERSION, about = "Promtuz resolver")]
+pub struct Cli {
+    /// Path to the config file.
+    #[arg(short, long, default_value = "/etc/promtuz/resolver.toml")]
+    pub config: PathBuf,
+}
+
+impl Cli {
+    /// Parse argv (handles `--version` / `--help` and exits as clap does).
+    pub fn get() -> Self {
+        Self::parse()
+    }
+}

--- a/resolver/src/main.rs
+++ b/resolver/src/main.rs
@@ -30,6 +30,9 @@ async fn main() -> Result<()> {
     // if not enrolled), so the endpoint is only built with usable TLS material.
     let csr_path = cli.config.with_extension("csr");
     common::node::enroll::ensure_enrolled(&cfg.network, &csr_path, "resolver").await?;
+    if cfg.network.watch_reload {
+        common::node::enroll::spawn_config_reload(cli.config.clone());
+    }
 
     let resolver = Arc::new(Resolver::new(cfg));
     let acceptor = Acceptor::new(resolver.endpoint.clone());

--- a/resolver/src/main.rs
+++ b/resolver/src/main.rs
@@ -3,6 +3,7 @@
 #![forbid(unsafe_code)]
 
 // mod proto;
+mod cli;
 mod quic;
 mod resolver;
 mod util;
@@ -19,13 +20,9 @@ use crate::util::config::AppConfig;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // `--version` / `-V`: report and exit before touching config or the runtime.
-    if std::env::args().skip(1).any(|a| a == "--version" || a == "-V") {
-        println!("pzresolver {} ({})", env!("CARGO_PKG_VERSION"), env!("PZ_GIT_SHA"));
-        return Ok(());
-    }
+    let cli = cli::Cli::get();
 
-    let cfg = AppConfig::load(true);
+    let cfg = AppConfig::load(&cli.config, true);
     common::server::log::init(cfg.log.level.as_deref());
     common::info!("pzresolver {} ({})", env!("CARGO_PKG_VERSION"), env!("PZ_GIT_SHA"));
 

--- a/resolver/src/main.rs
+++ b/resolver/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
     }
 
     let cfg = AppConfig::load(true);
+    common::server::log::init(cfg.log.level.as_deref());
     common::info!("pzresolver {} ({})", env!("CARGO_PKG_VERSION"), env!("PZ_GIT_SHA"));
 
     let resolver = Arc::new(Resolver::new(cfg));

--- a/resolver/src/main.rs
+++ b/resolver/src/main.rs
@@ -26,6 +26,11 @@ async fn main() -> Result<()> {
     common::server::log::init(cfg.log.level.as_deref());
     common::info!("pzresolver {} ({})", env!("CARGO_PKG_VERSION"), env!("PZ_GIT_SHA"));
 
+    // Hold here until we have a valid cert for our key (writes a CSR + waits
+    // if not enrolled), so the endpoint is only built with usable TLS material.
+    let csr_path = cli.config.with_extension("csr");
+    common::node::enroll::ensure_enrolled(&cfg.network, &csr_path, "resolver").await?;
+
     let resolver = Arc::new(Resolver::new(cfg));
     let acceptor = Acceptor::new(resolver.endpoint.clone());
 

--- a/resolver/src/resolver/mod.rs
+++ b/resolver/src/resolver/mod.rs
@@ -86,17 +86,17 @@ impl Resolver {
         // a placeholder string for `graceful!`'s log line.
         let secret = graceful!(
             secret_from_key(&cfg.network.key_path).map_err(|_| "see prior error"),
-            "failed to load resolver secret key:"
+            "loading the resolver key"
         );
 
-        graceful!(NodeKey::new(secret.verifying_key()), "unexpected key length mismatch")
+        graceful!(NodeKey::new(secret.verifying_key()), "deriving the resolver node id")
     }
 
     fn endpoint(cfg: &AppConfig) -> Endpoint {
-        let server_config = graceful!(Self::get_server_cfg(cfg), "failed to setup server config:");
+        let server_config = graceful!(Self::get_server_cfg(cfg), "building the TLS server config");
         let endpoint = graceful!(
             Endpoint::server(server_config, cfg.network.address),
-            "failed to start quic server:"
+            "starting the QUIC endpoint"
         );
 
         if let Ok(addr) = endpoint.local_addr() {

--- a/resolver/src/util/config.rs
+++ b/resolver/src/util/config.rs
@@ -11,6 +11,14 @@ use serde::Deserialize;
 pub struct AppConfig {
     pub network: NetworkConfig,
     // pub resolver: ResolverConfig,
+    #[serde(default)]
+    pub log: LogConfig,
+}
+
+#[derive(Deserialize, Debug, Default)]
+pub struct LogConfig {
+    /// trace|debug|info|warn|error. `PZ_LOG` env overrides. Default: info.
+    pub level: Option<String>,
 }
 
 impl AppConfig {

--- a/resolver/src/util/config.rs
+++ b/resolver/src/util/config.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -22,17 +21,14 @@ pub struct LogConfig {
 }
 
 impl AppConfig {
-    pub fn load(cls: bool) -> Self {
+    pub fn load(path: &Path, cls: bool) -> Self {
         if cls {
             print!("\x1B[2J\x1B[1;1H");
             std::io::stdout().flush().ok();
         }
 
-        let path = env::args().nth(1).unwrap_or_else(|| "config.toml".into());
-        let path = Path::new(&path);
-
         if !path.exists() {
-            common::error!("config.toml not found: {}", path.display());
+            common::error!("config not found: {}", path.display());
             std::process::exit(1);
         }
 

--- a/testnet/src/deploy.rs
+++ b/testnet/src/deploy.rs
@@ -186,7 +186,6 @@ fn relay_config(bind: SocketAddr, resolver_ipk_hex: &str, resolver_pub: SocketAd
          address = \"{bind}\"\n\
          cert_path = \"node.crt\"\n\
          key_path = \"node.key\"\n\
-         identity_key_path = \"node.key\"\n\
          root_ca_path = \"ca.pem\"\n\
          \n\
          [[resolver.seed]]\n\

--- a/testnet/src/sandbox.rs
+++ b/testnet/src/sandbox.rs
@@ -59,7 +59,7 @@ impl Sandbox {
             resolver_config(resolver_addr, &resolver_dir, &ca_path),
         )?;
         let resolver =
-            NodeProc::spawn("resolver", &resolver_bin, &["config.toml"], &resolver_dir, true)?;
+            NodeProc::spawn("resolver", &resolver_bin, &["--config", "config.toml"], &resolver_dir, true)?;
         resolver
             .wait_for_log("listening at QUIC", Duration::from_secs(10))
             .await
@@ -79,7 +79,7 @@ impl Sandbox {
                 relay_config(addr, &dir, &ca_path, &resolver_leaf.pubkey_hex, resolver_addr),
             )?;
             let node =
-                NodeProc::spawn(format!("relay-{i}"), &relay_bin, &["config.toml"], &dir, true)?;
+                NodeProc::spawn(format!("relay-{i}"), &relay_bin, &["--config", "config.toml"], &dir, true)?;
             node.wait_for_log("listening at QUIC", Duration::from_secs(10))
                 .await
                 .with_context(|| format!("relay-{i} did not bind"))?;
@@ -211,7 +211,6 @@ fn relay_config(
          address = \"{addr}\"\n\
          cert_path = \"{crt}\"\n\
          key_path = \"{key}\"\n\
-         identity_key_path = \"{key}\"\n\
          root_ca_path = \"{ca}\"\n\
          \n\
          [[resolver.seed]]\n\


### PR DESCRIPTION
## What

0.1.2 overhauls relay/resolver deployment + identity DX. A fresh `pzrelay` used to die with `ERROR SERVER_CFG_ERR: No such file or directory` and no path from "installed" to "running". This fixes that end to end.

- **One key per node.** The relay collapses its separate identity + TLS keypairs into a single Ed25519 key (matching the resolver). The CA cert now certifies _that_ key (`CN/SAN = relay_id`) — which is what client→relay SNI validation actually requires and couldn't satisfy before. `peer/1` relay↔relay is unchanged (still serves the in-memory self-signed NodeKey cert via the ALPN split).
- **Manual enrollment** (`common::node::enroll`). On first boot a node generates its key, writes a PKCS#10 CSR, and **waits** (watching the dir via `notify`) instead of crash-looping on a missing cert. `certgen sign <csr>` mints the cert; drop it in and the node starts. The private key never leaves the box.
- **Unified `/etc/promtuz` layout** — `ca.pem`, `{relay,resolver}.toml`, `keys/`, `certs/`. systemd `ReadWritePaths` opened narrowly for key-gen + CSR + cert. Service users stay split (`pzrelay`/`pzresolver`).
- **Leveled logging** — runtime gate on the existing colored macros (`[log] level` / `PZ_LOG`, default `info`). Opaque `_ERR:` startup codes → `anyhow` context. DHT "routing table sparse" logs on state-change, not every tick; packet hex behind `TRACE`.
- **clap CLI** — `--config` / `--version` / `--help`; config defaults to `/etc/promtuz/<role>.toml`.
- **Opt-in config reload** (`watch_reload`, default off): re-exec on a validated config change; a bad edit never crash-loops.

## Security

Fixes a CA cert-confusion bug introduced mid-branch and caught by automated review: `certgen sign` derived identity by byte-scanning the raw CSR DER, which an attacker could fool by smuggling a second SPKI into the (attacker-controlled) subject — yielding a CA cert whose real key is the attacker's but whose CN is a victim's `NodeId`. Now derives identity from the rcgen proof-of-possession-verified key and rejects non-Ed25519 CSRs.

## Validation

- **e2e sandbox harness PASS** — resolver + 2 relays + 2 clients; relays boot through enrollment, form the DHT over `peer/1`, and a 1:1 MLS message is decrypted across two relays.
- Scoped unit tests: `node::enroll` (cert validation, CSR round-trip via rcgen, full sign→validate loop) and `server::log` level gate.
- `cargo check --workspace` clean.

## Migration

None — at current scale existing nodes just re-enroll (fresh key + cert) on first 0.1.2 boot. If ever needed, it belongs in the deb postinst.